### PR TITLE
Guard unsupported bounty currency symbols

### DIFF
--- a/src/lib/commands.test.ts
+++ b/src/lib/commands.test.ts
@@ -1,4 +1,4 @@
-import { isValidBCHAddress, validateAddressForNetwork } from "./commands";
+import { isValidBCHAddress, parseCommand, validateAddressForNetwork } from "./commands";
 
 // Mock @bitauth/libauth to handle ESM import issues in Jest
 jest.mock("@bitauth/libauth", () => ({
@@ -43,6 +43,26 @@ jest.mock("@bitauth/libauth", () => ({
     };
   },
 }));
+
+describe("parseCommand currency handling", () => {
+  const refundAddress = "bitcoincash:qp3wjpa3tjlj042z2wv7hahskkprgllgnsjx3ryld";
+
+  it("should allow an explicit BCH currency after the amount", () => {
+    const result = parseCommand(`/bounty 0.01 BCH --refund ${refundAddress}`);
+
+    expect(result.success).toBe(true);
+    expect(result.amount).toBe(0.01);
+    expect(result.refundAddress).toBe(refundAddress);
+  });
+
+  it("should reject stablecoin symbols instead of silently treating them as BCH", () => {
+    const result = parseCommand(`/bounty 50 USDC --refund ${refundAddress}`);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("USDC");
+    expect(result.error).toContain("not supported yet");
+  });
+});
 
 describe("isValidBCHAddress", () => {
   describe("valid addresses", () => {

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -3,6 +3,9 @@ import { MIN_BOUNTY_BCH, MAX_BOUNTY_BCH } from "./constants";
 
 export type CommandType = "create" | "cancel";
 
+const SUPPORTED_BOUNTY_CURRENCY = "BCH";
+const KNOWN_STABLECOIN_SYMBOLS = new Set(["USDC", "USDT", "USDH", "FLEXUSD"]);
+
 export interface ParsedCommand {
   success: boolean;
   type?: CommandType;
@@ -24,6 +27,7 @@ export interface ParsedClaimCommand {
  *
  * Supported formats:
  * - /bounty 2.35 --refund bitcoincash:qp...
+ * - /bounty 2.35 BCH --refund bitcoincash:qp...
  * - /bounty 1.5 --refund bchtest:qp... --expiry 60
  * - /bounty 0.5 --refund bitcoincash:qp... --expiry 90
  */
@@ -62,6 +66,7 @@ export function parseCommand(command: string): ParsedCommand {
 
   const amountStr = tokens[0];
   const amount = parseFloat(amountStr);
+  let flagStartIndex = 1;
 
   if (isNaN(amount) || amount <= 0) {
     return {
@@ -88,11 +93,31 @@ export function parseCommand(command: string): ParsedCommand {
     };
   }
 
+  const maybeCurrency = tokens[1];
+  if (maybeCurrency && !maybeCurrency.startsWith("-")) {
+    const currency = maybeCurrency.toUpperCase();
+    flagStartIndex = 2;
+
+    if (currency !== SUPPORTED_BOUNTY_CURRENCY) {
+      if (KNOWN_STABLECOIN_SYMBOLS.has(currency)) {
+        return {
+          success: false,
+          error: `${currency} bounties are not supported yet. Please use BCH for now.`,
+        };
+      }
+
+      return {
+        success: false,
+        error: `Unsupported bounty currency: "${maybeCurrency}". Only BCH is supported right now.`,
+      };
+    }
+  }
+
   // Parse flags
   let refundAddress: string | undefined;
   let expiryDays: number = 90; // Default to 90 days
 
-  for (let i = 1; i < tokens.length; i++) {
+  for (let i = flagStartIndex; i < tokens.length; i++) {
     const token = tokens[i];
 
     if (token === "--refund" || token === "-r") {


### PR DESCRIPTION
## Summary
- allows an explicit `BCH` currency token after the bounty amount
- rejects known stablecoin symbols such as `USDC`, `USDT`, `USDH`, and `FLEXUSD` with a clear not-supported-yet error
- prevents commands like `/bounty 50 USDC --refund ...` from being silently parsed as a 50 BCH bounty
- adds regression tests for explicit BCH and unsupported stablecoin currency handling

## Verification
- `npm test -- src/lib/commands.test.ts --runInBand`
- `git diff --check`
- `npm run build` reaches Next.js compile and TypeScript successfully, then fails during prerender because local `DATABASE_URL` is not configured

Prepares #42