### PR TITLE
Implement structured webhook error logging

### DIFF
--- a/src/app/api/webhooks/github/route.ts
+++ b/src/app/api/webhooks/github/route.ts
@@ -15,6 +15,7 @@ import { handleIssueComment } from "@/lib/github/handlers/issue/comment";
 import { handleIssueClosed } from "@/lib/github/handlers/issue/closed";
 import { handlePullRequestOpenedOrEdited } from "@/lib/github/handlers/pull-request/opened-or-edited";
 import { handlePullRequestClosed } from "@/lib/github/handlers/pull-request/closed";
+import { logger } from "@/lib/logger";
 
 /**
  * Verify GitHub webhook signature
@@ -44,7 +45,7 @@ export async function POST(request: NextRequest) {
     // Verify webhook signature
     const webhookSecret = process.env.GITHUB_WEBHOOK_SECRET;
     if (!webhookSecret) {
-      console.error("GITHUB_WEBHOOK_SECRET not configured");
+      logger.error("GITHUB_WEBHOOK_SECRET not configured", { provider: "github" });
       return NextResponse.json(
         { error: "Webhook secret not configured" },
         { status: 500 },
@@ -55,7 +56,7 @@ export async function POST(request: NextRequest) {
       process.env.NODE_ENV !== "development" &&
       !verifyGitHubSignature(payload, signature, webhookSecret)
     ) {
-      console.error("Invalid webhook signature");
+      logger.warn("Invalid webhook signature", { provider: "github", event });
       return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
     }
 
@@ -70,7 +71,7 @@ export async function POST(request: NextRequest) {
       | IssuesOpenedEvent;
 
     // Log the event
-    console.log(`📨 GitHub webhook: ${event}`);
+    logger.info("GitHub webhook received", { provider: "github", event });
 
     // Route to appropriate handler
     let result: WebhookResponse;
@@ -134,7 +135,10 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json(result);
   } catch (error) {
-    console.error("Webhook error:", error);
+    logger.error("GitHub webhook error", {
+      provider: "github",
+      error: (error as Error).message,
+    });
     return NextResponse.json(
       {
         success: false,

--- a/src/app/api/webhooks/gitlab/route.ts
+++ b/src/app/api/webhooks/gitlab/route.ts
@@ -17,6 +17,7 @@ import { extractInstanceUrl } from "@/lib/gitlab/api";
 import { handleNoteOnIssue } from "@/lib/gitlab/handlers/note";
 import { handleIssueClosed } from "@/lib/gitlab/handlers/issue";
 import { handleMergeRequest } from "@/lib/gitlab/handlers/merge-request";
+import { logger } from "@/lib/logger";
 
 /**
  * GitLab Webhook Handler
@@ -37,7 +38,7 @@ export async function POST(request: NextRequest) {
 
     // Check for token
     if (!token) {
-      console.error("Missing X-Gitlab-Token header");
+      logger.warn("Missing X-Gitlab-Token header", { provider: "gitlab" });
       return NextResponse.json(
         { error: "Missing webhook token" },
         { status: 401 }
@@ -49,7 +50,7 @@ export async function POST(request: NextRequest) {
     try {
       data = JSON.parse(payload) as GitLabWebhookEvent;
     } catch {
-      console.error("Invalid JSON payload");
+      logger.warn("Invalid JSON payload", { provider: "gitlab" });
       return NextResponse.json(
         { error: "Invalid JSON payload" },
         { status: 400 }
@@ -59,7 +60,7 @@ export async function POST(request: NextRequest) {
     // Extract project info from payload
     const project = data.project;
     if (!project) {
-      console.error("Missing project in webhook payload");
+      logger.warn("Missing project in webhook payload", { provider: "gitlab" });
       return NextResponse.json(
         { error: "Missing project information" },
         { status: 400 }
@@ -77,9 +78,10 @@ export async function POST(request: NextRequest) {
     );
 
     if (!credentials) {
-      console.error(
-        `Invalid webhook token for project ${project.path_with_namespace}`
-      );
+      logger.warn("Invalid webhook token", {
+        provider: "gitlab",
+        project: project.path_with_namespace,
+      });
       return NextResponse.json(
         { error: "Invalid webhook token" },
         { status: 401 }
@@ -87,9 +89,11 @@ export async function POST(request: NextRequest) {
     }
 
     // Log the event
-    console.log(
-      `📨 GitLab webhook: ${event} from ${project.path_with_namespace}`
-    );
+    logger.info("GitLab webhook received", {
+      provider: "gitlab",
+      event,
+      project: project.path_with_namespace,
+    });
 
     // Route to appropriate handler
     let result: WebhookResponse;
@@ -120,7 +124,10 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json(result);
   } catch (error) {
-    console.error("GitLab webhook error:", error);
+    logger.error("GitLab webhook error", {
+      provider: "gitlab",
+      error: (error as Error).message,
+    });
     return NextResponse.json(
       {
         success: false,

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,19 @@
+type LogContext = Record<string, unknown>;
+
+function write(level: "error" | "warn" | "info", message: string, context?: LogContext) {
+  const payload = context ? { message, ...context } : { message };
+
+  console[level](JSON.stringify(payload));
+}
+
+export const logger = {
+  error(message: string, context?: LogContext) {
+    write("error", message, context);
+  },
+  warn(message: string, context?: LogContext) {
+    write("warn", message, context);
+  },
+  info(message: string, context?: LogContext) {
+    write("info", message, context);
+  },
+};


### PR DESCRIPTION
Fixes #21.

## Summary
- add a small structured logger helper
- log GitHub webhook auth/signature/handler failures with provider/event context
- log GitLab webhook auth/payload/token/handler failures with provider/project context

## Verification
- `yarn tsc --noEmit`
- `git diff --check`

Note: `yarn lint` currently fails on pre-existing require-import errors in `jest.config.js` and `scripts/generate-oracle-keys.js`; this PR does not touch those files.