### PR TITLE
Handle processed GitHub PR claims idempotently

### DIFF
--- a/src/lib/github/handlers/pull-request/closed.ts
+++ b/src/lib/github/handlers/pull-request/closed.ts
@@ -21,13 +21,9 @@ export async function handlePullRequestClosed(
 
   if (pull_request.merged === false) {
     try {
-      const attempt = await prisma.attempt.update({
+      const attempt = await prisma.attempt.findUnique({
         where: {
           prUrl: pull_request.html_url,
-        },
-        data: {
-          status: AttemptStatus.REJECTED,
-          updatedAt: new Date(),
         },
         include: {
           bounty: {
@@ -38,6 +34,30 @@ export async function handlePullRequestClosed(
               repoName: true,
             },
           },
+        },
+      });
+
+      if (!attempt) {
+        return {
+          success: true,
+          message: "No claim found for this PR",
+        };
+      }
+
+      if (attempt.status !== AttemptStatus.PENDING) {
+        return {
+          success: true,
+          message: `Claim already processed (status: ${attempt.status})`,
+        };
+      }
+
+      await prisma.attempt.update({
+        where: {
+          id: attempt.id,
+        },
+        data: {
+          status: AttemptStatus.REJECTED,
+          updatedAt: new Date(),
         },
       });
 
@@ -71,6 +91,13 @@ export async function handlePullRequestClosed(
         return {
           success: true,
           message: "No claim found for this merged PR",
+        };
+      }
+
+      if (attempt.status !== AttemptStatus.PENDING) {
+        return {
+          success: true,
+          message: `Claim already processed (status: ${attempt.status})`,
         };
       }
 


### PR DESCRIPTION
Fixes #21

## Summary
- Avoid exception-driven control flow when a closed GitHub PR has no registered claim.
- Skip already processed attempts before marking closed PRs rejected.
- Skip already processed attempts before payout on merged PR webhooks, preventing duplicate payout attempts/log noise on redeliveries.

## Verification
- `git diff --check`

Could not run full lint/typecheck in this shallow worktree because dependencies are not installed (`yarn lint` -> `eslint: not found`).
